### PR TITLE
Bugfix/E206

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,7 +15,7 @@
 - name: Create mariadb-server.cnf template
   template:
     src: mariadb-server.cnf
-    dest: "{{ mariadb_conf_dir}}/mariadb-server.cnf"
+    dest: "{{ mariadb_conf_dir }}/mariadb-server.cnf"
     owner: root
     group: root
     mode: "0644"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -21,6 +21,8 @@
     - '::1'
     - localhost
   when: mysqlrootpass.changed
+  tags:
+    - skip_ansible_lint
 
 - name: Save root password for mariadb
   copy:

--- a/templates/mariadb-server.cnf
+++ b/templates/mariadb-server.cnf
@@ -15,11 +15,11 @@
 [mysqld]
 character_set_server           = utf8
 datadir                        = {{ mariadb_datadir }}
-tmpdir                         = {{ mariadb_tmpdir}}
-log-error                      = {{ mariadb_logdir}}/mariadb.log
+tmpdir                         = {{ mariadb_tmpdir }}
+log-error                      = {{ mariadb_logdir }}/mariadb.log
 #
 ## let's use slow log too, to be able to analyse problems.
-slow-query-log-file            = {{ mariadb_logdir}}/slow_queries.log
+slow-query-log-file            = {{ mariadb_logdir }}/slow_queries.log
 long_query_time                = 5 # seconds
 
 # Instead of skip-networking the default is now to listen only on


### PR DESCRIPTION
- workaround for E503: Tasks that run when changed should likely be handlers
- E206: Variables should have spaces before and after: {{ var_name }}